### PR TITLE
Removed unnecessary import command

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -21,7 +21,6 @@ import requests
 import base64
 import json
 import urllib.parse
-import platform
 
 def parse_between(string, fr, to):
     start = string.find(fr) + len(fr)


### PR DESCRIPTION
I once wanted to colorize output, passing ANSI sequences to the terminal, which themselves are not supported in Windows, that's where `platform` module should have came in handy. However, I rejected this approach later, successfully forgetting to remove the `import`.